### PR TITLE
Correcting the AdBlock Plus format

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -31,7 +31,7 @@ def generateUnboundList(block_list: List[str]) -> List[str]:
     return [f"# {line}" for line in file_header.split("\n")]+[f"local-zone: \"{entry}\" redirect\nlocal-data: \"{entry} A 127.0.0.1\"" for entry in block_list]
 
 def generateAdblockList(block_list: List[str]) -> List[str]:
-    return ["[Adblock Plus 2.0]"]+[f"! {line}" for line in file_header.split("\n")]+[entry for entry in block_list]
+    return ["[Adblock Plus 2.0]"]+[f"! {line}" for line in file_header.split("\n")]+["||{}^".format(entry) for entry in block_list]
 
 
 # All generators


### PR DESCRIPTION
Pure domains cause issues in AdBlock Plus, uBlock Origin, and possibly AdGuard, so I have added || and ^ to the entries in the AdBlock Plus list
### References: 
https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#hosts-files
https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#example-blocking-by-domain-name-1
https://help.eyeo.com/en/adblockplus/how-to-write-filters?3910d1c0#anchors