### PR TITLE
Addition of FutureMind Adblock DNS Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following are links to the generated blocklists:
  - [DNSMASQ](https://ewpratten.github.io/youtube_ad_blocklist/dnsmasq.txt)
  - [unbound](https://ewpratten.github.io/youtube_ad_blocklist/unbound.txt)
  - [AdBlockPlus](https://ewpratten.github.io/youtube_ad_blocklist/adblockplus.txt)
+ - [FutureMind Adblock](https://ewpratten.github.io/youtube_ad_blocklist/futuremind.adblock)
 
 ## Credits
 

--- a/generator.py
+++ b/generator.py
@@ -33,6 +33,9 @@ def generateUnboundList(block_list: List[str]) -> List[str]:
 def generateAdblockList(block_list: List[str]) -> List[str]:
     return ["[Adblock Plus 2.0]"]+[f"! {line}" for line in file_header.split("\n")]+["||{}^".format(entry) for entry in block_list]
 
+def generateFutureMindList(block_list: List[str]) -> List[str]:
+    return ["# [FutureMind Adblock]"]+[f"# {line}" for line in file_header.split("\n")]+["YouTube Adservers/{}".format(entry) for entry in block_list]
+
 
 # All generators
 generator_list: dict = {
@@ -41,7 +44,8 @@ generator_list: dict = {
     "domains.txt": generateDomainsList,
     "dnsmasq.txt": generateDNSMASQList,
     "unbound.txt": generateUnboundList,
-    "adblockplus.txt": generateAdblockList
+    "adblockplus.txt": generateAdblockList,
+    "futuremind.adblock": generateFutureMindList
 }
 
 


### PR DESCRIPTION
I personally use and enjoy [FutureMind Adblocker](https://itunes.apple.com/us/app/adblock/id691121579) so I'd like to see a version of ["youtube_ad_blocklist"](https://github.com/Ewpratten/youtube_ad_blocklist) formatted for it.